### PR TITLE
Fix for headlock problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "prebuild": "npm run lint",
     "build": "babel src --out-dir dist",
+    "prepare": "npm run build",
     "prepublish": "npm run build",
     "lint": "eslint quickvr.js"
   },

--- a/src/quickvr.js
+++ b/src/quickvr.js
@@ -126,6 +126,10 @@ export default class App {
   }
 
   render() {
+    if (this.vrButton.isPresenting()) {
+      this.controls.update();
+    }
+
     this.effect.render(this.scene, this.camera);
 
     this.animations.forEach((animation, i, a) => {
@@ -133,10 +137,6 @@ export default class App {
     });
 
     this.vrDisplay.requestAnimationFrame(this.render);
-
-    if (this.vrButton.isPresenting()) {
-      this.controls.update();
-    }
   }
 
   resize(e) {


### PR DESCRIPTION
Fixes headlock on Oculus Browser. Head rotation wasn't working if you update controls after rendering. This also may have been causing a frame of latency on other platforms.

Tested with Oculus Browser and Daydream. 

I've filed an issue with the Oculus Browser team to better understand why this worked in Daydream but not Oculus Browser.

Update: The behavior difference between Oculus Browser and Daydream has been located and they'll line up in the next release. There is still a frame of latency without this change.